### PR TITLE
Add Final_Post database management UI

### DIFF
--- a/src/components/assistant/database-manager.tsx
+++ b/src/components/assistant/database-manager.tsx
@@ -1,0 +1,182 @@
+import dayjs from "dayjs"
+import { type ChangeEvent, type FormEventHandler, type ReactNode, useMemo, useState } from "react"
+import type { DatabaseEntryDraft, ExistingPost } from "./utils"
+
+interface DatabaseManagerProps {
+  entries: ExistingPost[]
+  onAdd: (entry: DatabaseEntryDraft) => void
+}
+
+function createInitialEntry(): DatabaseEntryDraft {
+  return {
+    title: "",
+    keywords: "",
+    dataPoints: "",
+    publishDate: dayjs().format("YYYY-MM-DD"),
+  }
+}
+
+export function DatabaseManager({ entries, onAdd }: DatabaseManagerProps) {
+  const [form, setForm] = useState<DatabaseEntryDraft>(createInitialEntry)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleChange = (field: keyof DatabaseEntryDraft) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const value = event.target.value
+    setForm(current => ({ ...current, [field]: value }))
+  }
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    const trimmed: DatabaseEntryDraft = {
+      title: form.title.trim(),
+      keywords: form.keywords.trim(),
+      dataPoints: form.dataPoints.trim(),
+      publishDate: form.publishDate.trim(),
+    }
+
+    if (!trimmed.title || !trimmed.keywords || !trimmed.dataPoints || !trimmed.publishDate) {
+      setError("Please complete title, keywords, data points, and publish date before adding.")
+      return
+    }
+
+    setError(null)
+    onAdd(trimmed)
+    setForm(createInitialEntry())
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("toast", { detail: { title: "Database updated", message: "Entry appended to Final_Post.md" } }))
+    }
+  }
+
+  const keywordsSummary = useMemo(() => {
+    const tally = new Map<string, number>()
+    entries.forEach((entry) => {
+      entry.keywords.forEach((keyword) => {
+        const current = tally.get(keyword) ?? 0
+        tally.set(keyword, current + 1)
+      })
+    })
+    return Array.from(tally.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 6)
+  }, [entries])
+
+  const existingRecordsContent = useMemo<ReactNode>(() => {
+    if (entries.length === 0) {
+      return <p className="text-xs text-neutral-500">No records loaded yet.</p>
+    }
+
+    return entries.map(entry => (
+      <article
+        key={entry.id}
+        className="space-y-1 rounded-lg border border-neutral-200/70 bg-neutral-50/60 px-3 py-2 text-xs dark:bg-neutral-900/60"
+      >
+        <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100">{entry.title}</p>
+        {entry.publishDate && (
+          <p className="text-[11px] text-neutral-500">
+            <span>Publish Date:</span>
+            <span className="ml-1">{entry.publishDate}</span>
+          </p>
+        )}
+        {entry.keywords.length > 0 && (
+          <p className="text-[11px] text-neutral-500">
+            <span>Keywords:</span>
+            <span className="ml-1">{entry.keywords.join(", ")}</span>
+          </p>
+        )}
+        {entry.dataPoints && (
+          <p className="text-[11px] text-neutral-500 line-clamp-2">
+            <span>Data Points:</span>
+            <span className="ml-1">{entry.dataPoints}</span>
+          </p>
+        )}
+      </article>
+    ))
+  }, [entries])
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-lg font-semibold">Final_Post database helper</h3>
+          <span className="text-xs text-neutral-500">{`${entries.length} historical posts loaded`}</span>
+        </div>
+        <p className="text-xs text-neutral-500">
+          Upload or paste your Final_Post.md above, then append new records here without leaving the planner.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-3">
+          <h4 className="text-sm font-semibold">Existing records</h4>
+          <div className="max-h-72 overflow-y-auto rounded-xl border border-neutral-300/60 p-3 space-y-3">
+            {existingRecordsContent}
+          </div>
+          {keywordsSummary.length > 0 && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-semibold">Top keywords</h4>
+              <ul className="grid grid-cols-2 gap-2 text-[11px] text-neutral-600 dark:text-neutral-300">
+                {keywordsSummary.map(([keyword, count]) => (
+                  <li key={keyword} className="rounded-full border border-neutral-200 px-3 py-1 text-center">
+                    {`${keyword} · ${count}`}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <h4 className="text-sm font-semibold">Add new record</h4>
+            <p className="text-[11px] text-neutral-500">
+              Complete every field to keep the historical database aligned with mandatory checks.
+            </p>
+          </div>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Title</span>
+            <input
+              value={form.title}
+              onChange={handleChange("title")}
+              placeholder="Theme or headline"
+              className="rounded-lg border border-neutral-300 bg-transparent px-3 py-2 focus:(outline-none border-primary)"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Keywords</span>
+            <input
+              value={form.keywords}
+              onChange={handleChange("keywords")}
+              placeholder="Separate with commas"
+              className="rounded-lg border border-neutral-300 bg-transparent px-3 py-2 focus:(outline-none border-primary)"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Data points</span>
+            <textarea
+              value={form.dataPoints}
+              onChange={handleChange("dataPoints")}
+              placeholder="Key metrics or findings"
+              className="min-h-24 rounded-lg border border-neutral-300 bg-transparent px-3 py-2 focus:(outline-none border-primary)"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Publish date</span>
+            <input
+              type="date"
+              value={form.publishDate}
+              onChange={handleChange("publishDate")}
+              className="rounded-lg border border-neutral-300 bg-transparent px-3 py-2 focus:(outline-none border-primary)"
+            />
+          </label>
+          {error && <p className="text-[11px] text-red-500">{error}</p>}
+          <button
+            type="submit"
+            className="rounded-full bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
+          >
+            Append to database text
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/assistant/utils.ts
+++ b/src/components/assistant/utils.ts
@@ -4,8 +4,17 @@ export interface ExistingPost {
   id: number
   title: string
   keywords: string[]
+  dataPoints: string
+  publishDate: string
   content: string
   raw: string
+}
+
+export interface DatabaseEntryDraft {
+  title: string
+  keywords: string
+  dataPoints: string
+  publishDate: string
 }
 
 export interface SourceEntry {
@@ -144,12 +153,16 @@ export function parseFinalPostDatabase(input: string): ExistingPost[] {
   return sections.map((section, index) => {
     const titleMatch = section.match(/Title:\s*(.+)/)
     const keywordsMatch = section.match(/Keywords?:\s*(.+)/i)
+    const dataPointsMatch = section.match(/Data Points?:\s*(.+)/i)
+    const publishDateMatch = section.match(/Publish Date:\s*(.+)/i)
     return {
       id: index + 1,
       title: titleMatch ? titleMatch[1].trim() : `Untitled ${index + 1}`,
       keywords: keywordsMatch
         ? keywordsMatch[1].split(/[，,]/).map(k => k.trim().toLowerCase()).filter(Boolean)
         : [],
+      dataPoints: dataPointsMatch ? dataPointsMatch[1].trim() : "",
+      publishDate: publishDateMatch ? publishDateMatch[1].trim() : "",
       content: section.trim(),
       raw: section,
     }

--- a/src/routes/assistant.tsx
+++ b/src/routes/assistant.tsx
@@ -1,9 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router"
 import dayjs from "dayjs"
 import { type ChangeEventHandler, useMemo, useState } from "react"
+import { DatabaseManager } from "~/components/assistant/database-manager"
 import { PostEditor } from "~/components/assistant/post-editor"
 import { bannedMatchers, finalChecklistItems, focusAreaOptions, priorityFocusIds } from "~/components/assistant/constraints"
-import type { ExistingPost, PostDraft, PostMetrics } from "~/components/assistant/utils"
+import type { DatabaseEntryDraft, ExistingPost, PostDraft, PostMetrics } from "~/components/assistant/utils"
 import {
   buildPostPreview,
   computeSimilarity,
@@ -176,6 +177,22 @@ function AssistantPlanner() {
     setExistingPosts(parseFinalPostDatabase(value))
   }
 
+  const handleAddDatabaseEntry = (entry: DatabaseEntryDraft) => {
+    const lines = [
+      `Title: ${entry.title}`,
+      `Keywords: ${entry.keywords}`,
+      `Data Points: ${entry.dataPoints}`,
+      `Publish Date: ${entry.publishDate}`,
+    ]
+    setDatabaseText((current) => {
+      const trimmed = current.trim()
+      const snippet = lines.join("\n")
+      const appended = trimmed ? `${trimmed}\n\n${snippet}` : snippet
+      setExistingPosts(parseFinalPostDatabase(appended))
+      return `${appended}\n`
+    })
+  }
+
   const updatePostField = (postId: number, field: keyof PostDraft, value: PostDraft[keyof PostDraft]) => {
     setPosts(current => current.map(post => (post.id === postId ? { ...post, [field]: value } : post)))
   }
@@ -278,6 +295,7 @@ function AssistantPlanner() {
           placeholder="Paste Final_Post.md content here to enable conflict checks."
           className="min-h-40 w-full rounded-xl border border-neutral-300 bg-transparent px-3 py-3 text-sm focus:(outline-none border-primary)"
         />
+        <DatabaseManager entries={existingPosts} onAdd={handleAddDatabaseEntry} />
       </section>
 
       <section className="rounded-2xl border border-primary/20 bg-base bg-op-70! p-6 space-y-4">


### PR DESCRIPTION
## Summary
- add a database manager panel so planners can review Final_Post entries and append new records directly in the app
- parse stored posts for data points and publish dates to support richer duplication checks
- wire the new manager into the assistant planner workflow to keep the textarea and parsed history in sync

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9f2d4d538832382977976d2cca038